### PR TITLE
Update Makefile for OpenWRT Trunk (>15.05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 ---------
+Curent
+===
++ Use i2c Port 1 now as default
++ get it working on OpenWRT Trunk
+
 
 0.3
 ===

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ssd1306_i2c
+PKG_NAME:=ssd1306-i2c
 PKG_VERSION:=0.3
 PKG_RELEASE:=1
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ define Package/ssd1306-i2c
   CATEGORY:=Languages
   TITLE:=ssd1306-i2c
   URL:=http://github.com/polkabana/bsb_ssd1306_i2c
-  DEPENDS:=+python-mini
+  DEPENDS:=+python-light
 endef
 
 define Package/ssd1306-i2c/description

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ define Package/ssd1306-i2c
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=ssd1306-i2c
-  URL:=http://github.com/polkabana/bsb_ssd1306_i2c
+  URL:=http://github.com/nmaas87/bsb_ssd1306_i2c
   DEPENDS:=+python-light
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@
 #
 
 include $(TOPDIR)/rules.mk
-
-PKG_NAME:=ssd1306-i2c
+PKG_NAME:=ssd1306_i2c
 PKG_VERSION:=0.3
 PKG_RELEASE:=1
 
@@ -18,16 +17,16 @@ PKG_BUILD_DEPENDS:=python
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 
-define Package/ssd1306-i2c
+define Package/ssd1306_i2c
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=ssd1306-i2c
-  URL:=http://github.com/nmaas87/bsb_ssd1306_i2c
+  TITLE:=ssd1306_i2c
+  #URL:=http://github.com/nmaas87/bsb_ssd1306_i2c
   DEPENDS:=+python-light
 endef
 
-define Package/ssd1306-i2c/description
+define Package/ssd1306_i2c/description
   serial port python bindings
 endef
 
@@ -42,11 +41,11 @@ define Build/Compile
 	)
 endef
 
-define Package/ssd1306-i2c/install
+define Package/ssd1306_i2c/install
 	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
 	$(CP) \
 	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
 	    $(1)$(PYTHON_PKG_DIR)/
 endef
 
-$(eval $(call BuildPackage,ssd1306-i2c))
+$(eval $(call BuildPackage,ssd1306_i2c))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run and say yes for new bsb_ssd1306_i2c package:
 Run for compile package:
 ```make *package/bsb_ssd1306_i2c/compile V=s*.```
 
-Check bin/ar71xx/packages/base/ for results (like ssd1306-i2c_0.1-1_ar71xx.ipk)
+Check bin/brcm2708/packages/base/ for results (like ssd1306-i2c_0.3-1_brcm2708.ipk)
 
 Usage
 -----
@@ -39,14 +39,14 @@ Connect your SSD1306 OLED display. Don't forget about pull-up resistors!
 
 Check your connections:
 ```
-i2cdetect -y 0
+i2cdetect -y 1
 ```
 
 Example programm
 
 ```python
 from ssd1306_i2c import SSD1306
-ssd = SSD1306(0, 0x3c) # /dev/i2c-0, device address 0x3c
+ssd = SSD1306(1, 0x3c) # /dev/i2c-1, device address 0x3c
 ssd.clear()
 ssd.circle(25, 25, 15, 1)
 ssd.line(0, 0, 127, 20, 1);


### PR DESCRIPTION
python-light as new Dependency, python-mini does not exisit anymore.